### PR TITLE
Fix Makefile on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS := -X main.Version=$(VERSION)
 default: install
 
 dep:
-	dep ensure
+	$(GOPATH)/bin/dep ensure
 
 get-deps:
 	go get -u github.com/golang/dep/cmd/dep


### PR DESCRIPTION
...and possibly on other platforms as well. While some Go developers
like to add $GOPATH/bin to their $PATH, that is an optional modification
that is not present in a default Go install and should not be relied
upon.

Implements https://github.com/TrueFurby/go-callvis/issues/11#issuecomment-330470865. Resolves #11.