### PR TITLE
Using SVG format with links to packages served via HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ the code much higher or when you are just simply trying to understand code of so
 - group functions by package and/or methods by type
 - filter packages to specific import path prefixes
 - omit various types of function calls
-- :new: interactive view using HTTP server that serves SVG images 
+- :boom: interactive view using HTTP server that serves SVG images 
   containing URLs on packages to change focused package dynamically
 
 ### Output preview
@@ -147,6 +147,6 @@ Each execution takes a lot of time, because currently:
 
 #### Roadmap
 
-##### The *interactive tool* described below has been published as a *separate project* called [goexplorer](https://github.com/TrueFurby/goexplorer)! :boom:
+##### The *interactive tool* described below has been published as a *separate project* called [goexplorer](https://github.com/TrueFurby/goexplorer)!
 
 > Ideal goal of this project is to make web app that would locally store the call graph data and then provide quick access of the call graphs for any package of your dependency tree. At first it would show an interactive map of overall dependencies between packages and then by selecting particular package it would show the call graph and provide various options to alter the output dynamically.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ the code much higher or when you are just simply trying to understand code of so
 
 ### Features
 
-- :new: interactive view using HTTP server that serves SVG images 
-  containing URLs on packages to change focused package dynamically
+- focus specific package in the program
 - group functions by package and/or methods by type
 - filter packages to specific import path prefixes
 - omit various types of function calls
+- :new: interactive view using HTTP server that serves SVG images 
+  containing URLs on packages to change focused package dynamically
 
 ### Output preview
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ the code much higher or when you are just simply trying to understand code of so
 
 ### Features
 
-- :new: output is now dynamically served via HTTP using SVG format with URL on packages for interactive view
+- :new: interactive view using HTTP server that serves SVG images 
+  containing URLs on packages to change focused package dynamically
 - group functions by package and/or methods by type
 - filter packages to specific import path prefixes
 - omit various types of function calls

--- a/README.md
+++ b/README.md
@@ -8,21 +8,22 @@
   <a href="https://gophers.slack.com/archives/go-callvis"><img src="https://img.shields.io/badge/gophers%20slack-%23go--callvis-ff69b4.svg" alt="Slack channel"></a>
 </p>
 
-<p align="center"><b>go-callvis</b> is a development tool to help visualize call graph of your Go program using Graphviz's dot format.</p>
+<p align="center"><b>go-callvis</b> is a development tool to help visualize call graph of a Go program using interactive view.</p>
 
 ---
 
 ## Introduction
 
-Purpose of this tool is to provide a visual overview of your program by using the data from call graph and its relations with packages and types. This is especially useful in larger projects where the complexity of the code rises or when you are just simply trying to understand code structure of somebody else.
+The purpose of this tool is to provide developers with a visual overview of a Go program using data from call graph 
+and its relations with packages and types. This is especially useful in larger projects where the complexity of 
+the code much higher or when you are just simply trying to understand code of somebody else.
 
 ### Features
 
-- focus specific package in a program
-- group functions by package and methods by type
-- limit packages to custom path prefixes
-- ignore packages containing path prefixes
-- omit calls from/to std packages
+- :new: output is now dynamically served via HTTP using SVG format with URL on packages for interactive view
+- group functions by package and/or methods by type
+- filter packages to specific import path prefixes
+- omit various types of function calls
 
 ### Output preview
 
@@ -32,53 +33,40 @@ Purpose of this tool is to provide a visual overview of your program by using th
 
 ### How it works
 
-It runs [pointer analysis](https://godoc.org/golang.org/x/tools/go/pointer) to construct the call graph of the program and uses the data to generate output in [dot format](http://www.graphviz.org/content/dot-language), which can be rendered with Graphviz tools.
+It runs [pointer analysis](https://godoc.org/golang.org/x/tools/go/pointer) to construct the call graph of the program and 
+uses the data to generate output in [dot format](http://www.graphviz.org/content/dot-language), which can be rendered with Graphviz tools.
 
 ## Reference guide
 
-Here you can find descriptions for all possible kinds of calls and groups.
+Here you can find descriptions for various types of output.
 
 ### Packages / Types
 
-###### Represented as subgraphs (clusters) in output.
-
-**Packages**
-- _**normal** corners_
-- _label on the **top**_
-
-**Types**
-- _**rounded** corners_
-- _label on the **bottom**_
-
 Represents  | Style
 ----------: | :-------------
-`focused`   | _**blue** color_
-`stdlib`    | _**green** color_
-`other`     | _**yellow** color_
+`focused`   | **blue** color
+`stdlib`    | **green** color
+`other`     | **yellow** color
 
 ### Functions / Methods
 
-###### Represented as nodes in output.
-
 Represents   | Style
 -----------: | :--------------
-`exported`   | _**bold** border_
-`unexported` | _**normal** border_
-`anonymous`  | _**dotted** border_
+`exported`   | **bold** border
+`unexported` | **normal** border
+`anonymous`  | **dotted** border
 
 ### Calls
 
-###### Represented as edges in output.
-
 Represents   | Style
 -----------: | :-------------
-`internal`   | _**black** color_
-`external`   | _**brown** color_
-`static`     | _**solid** line_
-`dynamic`    | _**dashed** line_
-`regular`    | _**simple** arrow_
-`concurrent` | _arrow with **circle**_
-`deferred`   | _arrow with **diamond**_
+`internal`   | **black** color
+`external`   | **brown** color
+`static`     | **solid** line
+`dynamic`    | **dashed** line
+`regular`    | **simple** arrow
+`concurrent` | arrow with **circle**
+`deferred`   | arrow with **diamond**
 
 ## Quick start
 
@@ -96,26 +84,36 @@ cd $GOPATH/src/github.com/TrueFurby/go-callvis && make
 
 ### Usage
 
-`go-callvis [OPTIONS] <main pkg> | dot -Tpng -o output.png`
+`go-callvis [flags] <main package>`
 
-### Options
+This will start HTTP server listening at [http://localhost:7878/](http://localhost:7878/). You can change it via `-http` flag. 
+
+#### Flags
 
 ```
 -focus string
       Focus package with import path or name. (default: main)
--limit string
-      Limit package paths to prefix. (separate multiple by comma)
 -group string
-      Grouping functions by [pkg, type]. (separate multiple by comma)
+    Grouping functions by packages and/or types. [pkg, type] (separated by comma)
+-http string
+	HTTP service address. (default ":7878")
+-limit string
+    Limit package paths to prefix. (separated by comma)
 -ignore string
-      Ignore package paths with prefix. (separate multiple by comma)
+    Ignore package paths with prefix. (separated by comma)
+-include string
+   	Include package paths with given prefixes (separated by comma)
+-nointer
+	Omit calls to unexported functions.
 -nostd
-      Omit calls from/to std packages.
--minlen uint
-      Minimum edge length (for wider output). (default: 2)
--nodesep float
-      Minimum space between two adjacent nodes in the same rank (for taller output). (default: 0.35)
+	Omit calls to/from packages in standard library.
+-tags build tags
+	a list of build tags to consider satisfied during the build.
+-tests
+	Include test code.
 ```
+
+Run `go-callvis -h` to list all supported flags.
 
 ## Examples
 
@@ -133,22 +131,22 @@ Join [#go-callvis](https://gophers.slack.com/archives/go-callvis) channel at [go
 
 ### How to help
 
-###### Did you find any bugs or have some suggestions?
-Feel free to open [new issue](https://github.com/TrueFurby/go-callvis/issues/new) or start discussion in the slack channel.
+Did you find any bugs or have some suggestions?
+- Feel free to open [new issue](https://github.com/TrueFurby/go-callvis/issues/new) or start discussion in the slack channel.
 
-###### Do you want to contribute to the development?
-Fork the project and do a pull request. [Here](https://github.com/TrueFurby/go-callvis/projects/1) you can find the state of features.
+Do you want to contribute to the project?
+- Fork the repository and open a pull request. [Here](https://github.com/TrueFurby/go-callvis/projects/1) you can find TODO features.
 
 ### Known Issues
 
-###### Each execution takes a lot of time, because currently:
+Each execution takes a lot of time, because currently:
 - the call graph is always generated for the entire program
 - there is yet no caching of call graph data
 
 ---
 
-### Roadmap
+#### Roadmap
 
-#### The *interactive tool* described below has been published as a *separate project* called [goexplorer](https://github.com/TrueFurby/goexplorer)! :boom:
+##### The *interactive tool* described below has been published as a *separate project* called [goexplorer](https://github.com/TrueFurby/goexplorer)! :boom:
 
 > Ideal goal of this project is to make web app that would locally store the call graph data and then provide quick access of the call graphs for any package of your dependency tree. At first it would show an interactive map of overall dependencies between packages and then by selecting particular package it would show the call graph and provide various options to alter the output dynamically.

--- a/README.md
+++ b/README.md
@@ -127,9 +127,7 @@ Here is an example for the project [syncthing](https://github.com/syncthing/sync
 
 ## Community
 
-Join [#go-callvis](https://gophers.slack.com/archives/go-callvis) channel at [gophers.slack.com](http://gophers.slack.com).
-
-> *Not a member yet?* [Get invitation](https://gophersinvite.herokuapp.com).
+Join [#go-callvis](https://gophers.slack.com/archives/go-callvis) channel at [gophers.slack.com](http://gophers.slack.com). (*not a member yet?* [get invitation](https://gophersinvite.herokuapp.com))
 
 ### How to help
 

--- a/analysis.go
+++ b/analysis.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/pointer"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+type analysis struct {
+	conf   loader.Config
+	pkgs   []*ssa.Package
+	mains  []*ssa.Package
+	result *pointer.Result
+}
+
+func newAnalysis(buildCtx *build.Context, tests bool, args []string) *analysis {
+	t0 := time.Now()
+	conf := loader.Config{Build: buildCtx}
+	_, err := conf.FromArgs(args, tests)
+	if err != nil {
+		log.Fatalln("invalid args:", err)
+	}
+	load, err := conf.Load()
+	if err != nil {
+		log.Fatalln("failed conf load:", err)
+	}
+	logf("loading.. %d imported (%d created) took: %v",
+		len(load.Imported), len(load.Created), time.Since(t0))
+
+	t0 = time.Now()
+
+	prog := ssautil.CreateProgram(load, 0)
+	prog.Build()
+	pkgs := prog.AllPackages()
+
+	var mains []*ssa.Package
+	if tests {
+		for _, pkg := range pkgs {
+			if main := prog.CreateTestMainPackage(pkg); main != nil {
+				mains = append(mains, main)
+			}
+		}
+		if mains == nil {
+			log.Fatalln("no tests")
+		}
+	} else {
+		mains = append(mains, ssautil.MainPackages(pkgs)...)
+		if len(mains) == 0 {
+			log.Fatalln("no main packages")
+		}
+	}
+	logf("building.. %d packages (%d main) took: %v",
+		len(pkgs), len(mains), time.Since(t0))
+
+	t0 = time.Now()
+	ptrcfg := &pointer.Config{
+		Mains:          mains,
+		BuildCallGraph: true,
+	}
+	result, err := pointer.Analyze(ptrcfg)
+	if err != nil {
+		log.Fatalln("analyze failed:", err)
+	}
+	logf("analysis took: %v", time.Since(t0))
+
+	return &analysis{
+		conf:   conf,
+		pkgs:   pkgs,
+		mains:  mains,
+		result: result,
+	}
+}
+
+func (a *analysis) handler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" && !strings.HasSuffix(r.URL.Path, ".svg") {
+		http.NotFound(w, r)
+		return
+	}
+
+	logf("----------------------")
+	logf(" => handling request:  %v", r.URL)
+	logf("----------------------")
+
+	focus := *focusFlag
+	nostd := *nostdFlag
+	nointer := *nointerFlag
+	group := *groupFlag
+	limit := *limitFlag
+	ignore := *ignoreFlag
+	include := *includeFlag
+
+	if f := r.FormValue("f"); f == "all" {
+		focus = ""
+	} else if f != "" {
+		focus = f
+	}
+	if std := r.FormValue("std"); std != "" {
+		nostd = false
+	}
+	if inter := r.FormValue("nointer"); inter != "" {
+		nointer = true
+	}
+	if g := r.FormValue("group"); g != "" {
+		group = g
+	}
+	if l := r.FormValue("limit"); l != "" {
+		limit = l
+	}
+	if ign := r.FormValue("ignore"); ign != "" {
+		ignore = ign
+	}
+	if inc := r.FormValue("include"); inc != "" {
+		include = inc
+	}
+
+	groupBy := make(map[string]bool)
+	for _, g := range strings.Split(group, ",") {
+		g := strings.TrimSpace(g)
+		if g == "" {
+			continue
+		}
+		if g != "pkg" && g != "type" {
+			http.Error(w, "invalid group option", http.StatusInternalServerError)
+			return
+		}
+		groupBy[g] = true
+	}
+
+	var limitPaths []string
+	for _, p := range strings.Split(limit, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			limitPaths = append(limitPaths, p)
+		}
+	}
+
+	var ignorePaths []string
+	for _, p := range strings.Split(ignore, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			ignorePaths = append(ignorePaths, p)
+		}
+	}
+
+	var includePaths []string
+	for _, p := range strings.Split(include, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			includePaths = append(includePaths, p)
+		}
+	}
+
+	var err error
+	var focusPkg *build.Package
+	if focus != "" {
+		focusPkg, err = a.conf.Build.Import(focus, "", 0)
+		if err != nil {
+			if strings.Contains(focus, "/") {
+				http.Error(w, "focus failed", http.StatusInternalServerError)
+				return
+			}
+			// try to find package by name
+			var foundPaths []string
+			for _, p := range a.pkgs {
+				if p.Pkg.Name() == focus {
+					foundPaths = append(foundPaths, p.Pkg.Path())
+				}
+			}
+			if len(foundPaths) == 0 {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			} else if len(foundPaths) > 1 {
+				for _, p := range foundPaths {
+					fmt.Fprintf(os.Stderr, " - %s\n", p)
+				}
+				err := fmt.Errorf("found %d packages with name %q, use import path not name", len(foundPaths), focus)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if focusPkg, err = a.conf.Build.Import(foundPaths[0], "", 0); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+		logf("focusing: %v", focusPkg.ImportPath)
+	}
+
+	dot, err := printOutput(a.mains[0].Pkg, a.result.CallGraph,
+		focusPkg, limitPaths, ignorePaths, includePaths, groupBy, nostd, nointer)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if r.Form.Get("format") == "dot" {
+		log.Println("writing dot output..")
+		fmt.Fprint(w, dot)
+		return
+	}
+
+	log.Println("converting dot to svg..")
+	img, err := dotToImage(dot)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Println("serving file:", img)
+	http.ServeFile(w, r, img)
+}

--- a/analysis.go
+++ b/analysis.go
@@ -94,6 +94,7 @@ type renderOpts struct {
 func (a *analysis) render(opts renderOpts) ([]byte, error) {
 	var err error
 	var focusPkg *build.Package
+
 	if opts.focus != "" {
 		focusPkg, err = a.conf.Build.Import(opts.focus, "", 0)
 		if err != nil {

--- a/dot.go
+++ b/dot.go
@@ -50,7 +50,7 @@ const tmplGraph = `digraph gocallvis {
     pad="0.0";
     nodesep="{{.Options.nodesep}}";
 
-    node [shape="ellipse" style="filled" fillcolor="honeydew" fontname="Tahoma" penwidth="1.0" margin="0.05,0.0"];
+    node [shape="ellipse" style="filled" fillcolor="honeydew" fontname="Verdana" penwidth="1.0" margin="0.05,0.0"];
     edge [minlen="{{.Options.minlen}}"]
 
     {{template "cluster" .Cluster}}

--- a/dot.go
+++ b/dot.go
@@ -4,16 +4,40 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"text/template"
 )
 
+// location of dot executable for converting from .dot to .svg
+// it's usually at: /usr/bin/dot
+var dotExe string
+
+func dotToImage(dot string) (string, error) {
+	if dotExe == "" {
+		dot, err := exec.LookPath("dot")
+		if err != nil {
+			log.Fatalln("unable to find program 'dot', please install it or check your PATH")
+		}
+		dotExe = dot
+	}
+
+	img := filepath.Join(os.TempDir(), fmt.Sprintf("go-callvis_export.svg"))
+	cmd := exec.Command(dotExe, "-Tsvg", "-o", img)
+	cmd.Stdin = strings.NewReader(dot)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return img, nil
+}
+
 var (
 	minlen  uint
 	nodesep float64
-)
 
-var (
 	FontTitle = "Consolas"
 	FontNode  = "Tahoma"
 )

--- a/dot.go
+++ b/dot.go
@@ -13,6 +13,11 @@ var (
 	nodesep float64
 )
 
+var (
+	FontTitle = "Consolas"
+	FontNode  = "Tahoma"
+)
+
 const tmplCluster = `{{define "cluster" -}}
     {{printf "subgraph %q {" .}}
         {{printf "%s" .Attrs.Lines}}
@@ -36,8 +41,8 @@ const tmplEdge = `{{define "node" -}}
 const tmplGraph = `digraph gocallvis {
     label="{{.Title}}";
     labeljust="l";
-    fontname="Ubuntu";
-    fontsize="13";
+    fontname="Arial";
+    fontsize="14";
     rankdir="LR";
     bgcolor="lightgray";
     style="solid";
@@ -45,7 +50,7 @@ const tmplGraph = `digraph gocallvis {
     pad="0.0";
     nodesep="{{.Options.nodesep}}";
 
-    node [shape="ellipse" style="filled" fillcolor="honeydew" fontname="Ubuntu" penwidth="1.0" margin="0.05,0.0"];
+    node [shape="ellipse" style="filled" fillcolor="honeydew" fontname="Tahoma" penwidth="1.0" margin="0.05,0.0"];
     edge [minlen="{{.Options.minlen}}"]
 
     {{template "cluster" .Cluster}}

--- a/dot.go
+++ b/dot.go
@@ -12,11 +12,16 @@ import (
 	"text/template"
 )
 
+var (
+	minlen  uint
+	nodesep float64
+)
+
 // location of dot executable for converting from .dot to .svg
 // it's usually at: /usr/bin/dot
 var dotExe string
 
-func dotToImage(dot string) (string, error) {
+func dotToImage(dot []byte) (string, error) {
 	if dotExe == "" {
 		dot, err := exec.LookPath("dot")
 		if err != nil {
@@ -27,17 +32,14 @@ func dotToImage(dot string) (string, error) {
 
 	img := filepath.Join(os.TempDir(), fmt.Sprintf("go-callvis_export.svg"))
 	cmd := exec.Command(dotExe, "-Tsvg", "-o", img)
-	cmd.Stdin = strings.NewReader(dot)
+	cmd.Stdin = bytes.NewReader(dot)
 	if err := cmd.Run(); err != nil {
 		return "", err
 	}
 	return img, nil
 }
 
-var (
-	minlen  uint
-	nodesep float64
-
+const (
 	FontTitle = "Consolas"
 	FontNode  = "Tahoma"
 )

--- a/main.go
+++ b/main.go
@@ -9,13 +9,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
-	"time"
-
-	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/go/pointer"
-	"golang.org/x/tools/go/ssa"
-	"golang.org/x/tools/go/ssa/ssautil"
 )
 
 var (
@@ -36,19 +29,23 @@ var (
 	httpFlag    = flag.String("http", ":7878", "HTTP service address.")
 )
 
-func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: go-callvis [flags] package\n")
-	fmt.Fprintf(os.Stderr, "\n")
-	flag.PrintDefaults()
-	os.Exit(2)
-}
-
 func init() {
 	// Graphviz options
 	flag.UintVar(&minlen, "minlen", 2, "Minimum edge length (for wider output).")
 	flag.Float64Var(&nodesep, "nodesep", 0.35, "Minimum space between two adjacent nodes in the same rank (for taller output).")
-	flag.Usage = usage
 }
+
+const Usage = `go-callvis: visualize call graph of a Go program.
+
+Usage:
+
+  go-callvis [flags] package
+
+  Package must be main package otherwise -tests flag must be used.
+
+Flags:
+
+`
 
 func main() {
 	flag.Parse()
@@ -61,220 +58,25 @@ func main() {
 		log.SetFlags(log.Lmicroseconds)
 	}
 
-	withTests := *testFlag
-	httpAddr := *httpFlag
-
 	args := flag.Args()
 	if flag.NArg() != 1 {
-		usage()
+		fmt.Fprintf(os.Stderr, Usage)
+		flag.PrintDefaults()
+		os.Exit(2)
 	}
 
-	t0 := time.Now()
-	conf := loader.Config{Build: &build.Default}
-	_, err := conf.FromArgs(args, withTests)
-	if err != nil {
-		log.Fatalln("invalid args:", err)
-	}
-	load, err := conf.Load()
-	if err != nil {
-		log.Fatalln("failed conf load:", err)
-	}
-	logf("loading.. %d imported (%d created) took: %v",
-		len(load.Imported), len(load.Created), time.Since(t0))
+	tests := *testFlag
+	httpAddr := *httpFlag
 
-	t0 = time.Now()
-	prog := ssautil.CreateProgram(load, 0)
-	prog.Build()
-	pkgs := prog.AllPackages()
-
-	var mains []*ssa.Package
-	if withTests {
-		for _, pkg := range pkgs {
-			if main := prog.CreateTestMainPackage(pkg); main != nil {
-				mains = append(mains, main)
-			}
-		}
-		if mains == nil {
-			log.Fatalln("no tests")
-		}
-	} else {
-		mains = append(mains, ssautil.MainPackages(pkgs)...)
-		if len(mains) == 0 {
-			log.Fatalln("no main packages")
-		}
-	}
-	logf("building.. %d packages (%d main) took: %v",
-		len(pkgs), len(mains), time.Since(t0))
-
-	t0 = time.Now()
-	ptrcfg := &pointer.Config{
-		Mains:          mains,
-		BuildCallGraph: true,
-	}
-	result, err := pointer.Analyze(ptrcfg)
-	if err != nil {
-		log.Fatalln("analyze failed:", err)
-	}
-	logf("analysis took: %v", time.Since(t0))
-
-	a := analysis{
-		conf:   conf,
-		pkgs:   pkgs,
-		mains:  mains,
-		result: result,
-	}
+	a := newAnalysis(&build.Default, tests, args)
 
 	http.HandleFunc("/", a.handler)
 
 	log.Printf("http serving at %s", httpAddr)
+
 	if err := http.ListenAndServe(httpAddr, nil); err != nil {
 		log.Fatal(err)
 	}
-}
-
-type analysis struct {
-	conf   loader.Config
-	pkgs   []*ssa.Package
-	mains  []*ssa.Package
-	result *pointer.Result
-}
-
-func (a *analysis) handler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" && !strings.HasSuffix(r.URL.Path, ".svg") {
-		http.NotFound(w, r)
-		return
-	}
-
-	logf("----------------------")
-	logf(" => handling request:  %v", r.URL)
-	logf("----------------------")
-
-	focus := *focusFlag
-	nostd := *nostdFlag
-	nointer := *nointerFlag
-	group := *groupFlag
-	limit := *limitFlag
-	ignore := *ignoreFlag
-	include := *includeFlag
-
-	if f := r.FormValue("f"); f == "all" {
-		focus = ""
-	} else if f != "" {
-		focus = f
-	}
-	if std := r.FormValue("std"); std != "" {
-		nostd = false
-	}
-	if inter := r.FormValue("nointer"); inter != "" {
-		nointer = true
-	}
-	if g := r.FormValue("group"); g != "" {
-		group = g
-	}
-	if l := r.FormValue("limit"); l != "" {
-		limit = l
-	}
-	if ign := r.FormValue("ignore"); ign != "" {
-		ignore = ign
-	}
-	if inc := r.FormValue("include"); inc != "" {
-		include = inc
-	}
-
-	groupBy := make(map[string]bool)
-	for _, g := range strings.Split(group, ",") {
-		g := strings.TrimSpace(g)
-		if g == "" {
-			continue
-		}
-		if g != "pkg" && g != "type" {
-			http.Error(w, "invalid group option", http.StatusInternalServerError)
-			return
-		}
-		groupBy[g] = true
-	}
-
-	var limitPaths []string
-	for _, p := range strings.Split(limit, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			limitPaths = append(limitPaths, p)
-		}
-	}
-
-	var ignorePaths []string
-	for _, p := range strings.Split(ignore, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			ignorePaths = append(ignorePaths, p)
-		}
-	}
-
-	var includePaths []string
-	for _, p := range strings.Split(include, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			includePaths = append(includePaths, p)
-		}
-	}
-
-	var err error
-	var focusPkg *build.Package
-	if focus != "" {
-		focusPkg, err = a.conf.Build.Import(focus, "", 0)
-		if err != nil {
-			if strings.Contains(focus, "/") {
-				http.Error(w, "focus failed", http.StatusInternalServerError)
-				return
-			}
-			// try to find package by name
-			var foundPaths []string
-			for _, p := range a.pkgs {
-				if p.Pkg.Name() == focus {
-					foundPaths = append(foundPaths, p.Pkg.Path())
-				}
-			}
-			if len(foundPaths) == 0 {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			} else if len(foundPaths) > 1 {
-				for _, p := range foundPaths {
-					fmt.Fprintf(os.Stderr, " - %s\n", p)
-				}
-				err := fmt.Errorf("found %d packages with name %q, use import path not name", len(foundPaths), focus)
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			if focusPkg, err = a.conf.Build.Import(foundPaths[0], "", 0); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-		}
-		logf("focusing: %v", focusPkg.ImportPath)
-	}
-
-	dot, err := printOutput(a.mains[0].Pkg, a.result.CallGraph,
-		focusPkg, limitPaths, ignorePaths, includePaths, groupBy, nostd, nointer)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if r.Form.Get("format") == "dot" {
-		log.Println("writing dot output..")
-		fmt.Fprint(w, dot)
-		return
-	}
-
-	log.Println("converting dot to svg..")
-	img, err := dotToImage(dot)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	log.Println("serving file:", img)
-	http.ServeFile(w, r, img)
 }
 
 func logf(f string, a ...interface{}) {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 )
 
 var (
@@ -68,15 +69,128 @@ func main() {
 	tests := *testFlag
 	httpAddr := *httpFlag
 
-	a := newAnalysis(&build.Default, tests, args)
+	doAnalysis(&build.Default, tests, args)
 
-	http.HandleFunc("/", a.handler)
+	http.HandleFunc("/", handler)
 
 	log.Printf("http serving at %s", httpAddr)
 
 	if err := http.ListenAndServe(httpAddr, nil); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" && !strings.HasSuffix(r.URL.Path, ".svg") {
+		http.NotFound(w, r)
+		return
+	}
+
+	logf("----------------------")
+	logf(" => handling request:  %v", r.URL)
+	logf("----------------------")
+
+	focus := *focusFlag
+	nostd := *nostdFlag
+	nointer := *nointerFlag
+	group := *groupFlag
+	limit := *limitFlag
+	ignore := *ignoreFlag
+	include := *includeFlag
+
+	if f := r.FormValue("f"); f == "all" {
+		focus = ""
+	} else if f != "" {
+		focus = f
+	}
+	if std := r.FormValue("std"); std != "" {
+		nostd = false
+	}
+	if inter := r.FormValue("nointer"); inter != "" {
+		nointer = true
+	}
+	if g := r.FormValue("group"); g != "" {
+		group = g
+	}
+	if l := r.FormValue("limit"); l != "" {
+		limit = l
+	}
+	if ign := r.FormValue("ignore"); ign != "" {
+		ignore = ign
+	}
+	if inc := r.FormValue("include"); inc != "" {
+		include = inc
+	}
+
+	var groupBy []string
+	for _, g := range strings.Split(group, ",") {
+		g := strings.TrimSpace(g)
+		if g == "" {
+			continue
+		}
+		if g != "pkg" && g != "type" {
+			http.Error(w, "invalid group option", http.StatusInternalServerError)
+			return
+		}
+		groupBy = append(groupBy, g)
+	}
+
+	var ignorePaths []string
+	for _, p := range strings.Split(ignore, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			ignorePaths = append(ignorePaths, p)
+		}
+	}
+
+	var includePaths []string
+	for _, p := range strings.Split(include, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			includePaths = append(includePaths, p)
+		}
+	}
+
+	var limitPaths []string
+	for _, p := range strings.Split(limit, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			limitPaths = append(limitPaths, p)
+		}
+	}
+
+	opts := renderOpts{
+		focus:   focus,
+		group:   groupBy,
+		ignore:  ignorePaths,
+		include: includePaths,
+		limit:   limitPaths,
+		nointer: nointer,
+		nostd:   nostd,
+	}
+
+	output, err := Analysis.render(opts)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if r.Form.Get("format") == "dot" {
+		log.Println("writing dot output..")
+		fmt.Fprint(w, output)
+		return
+	}
+
+	log.Println("converting dot to svg..")
+	img, err := dotToImage(output)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Println("serving file:", img)
+	http.ServeFile(w, r, img)
+
 }
 
 func logf(f string, a ...interface{}) {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	"golang.org/x/tools/go/buildutil"
 )
 
 var (
@@ -31,6 +33,7 @@ var (
 )
 
 func init() {
+	flag.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "tags", buildutil.TagsFlagDoc)
 	// Graphviz options
 	flag.UintVar(&minlen, "minlen", 2, "Minimum edge length (for wider output).")
 	flag.Float64Var(&nodesep, "nodesep", 0.35, "Minimum space between two adjacent nodes in the same rank (for taller output).")

--- a/output.go
+++ b/output.go
@@ -254,7 +254,7 @@ func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Pa
 							"fillcolor": "lightyellow",
 							"URL":       fmt.Sprintf("/?f=%s", key),
 							"fontname":  "bold",
-							"tooltip":   fmt.Sprintf("package %s", label),
+							"tooltip":   fmt.Sprintf("package: %s", label),
 						},
 					}
 					if pkg.Goroot {
@@ -280,6 +280,7 @@ func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Pa
 							"labelloc":  "b",
 							"style":     "rounded,filled",
 							"fillcolor": "wheat2",
+							"tooltip":   fmt.Sprintf("type: %s", label),
 						},
 					}
 					if isFocused {

--- a/output.go
+++ b/output.go
@@ -21,9 +21,15 @@ func inStd(node *callgraph.Node) bool {
 }
 
 func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Package,
-	limitPaths, ignorePaths, includePaths []string, groupBy map[string]bool, nostd, nointer bool) (string, error) {
-	groupType := groupBy["type"]
-	groupPkg := groupBy["pkg"]
+	limitPaths, ignorePaths, includePaths []string, groupBy []string, nostd, nointer bool) ([]byte, error) {
+	var groupType, groupPkg bool
+	for _, g := range groupBy {
+		if g == "pkg" {
+			groupPkg = true
+		} else if g == "type" {
+			groupType = true
+		}
+	}
 
 	cluster := NewDotCluster("focus")
 	cluster.Attrs = dotAttrs{
@@ -347,7 +353,7 @@ func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Pa
 		return nil
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	logf("%d/%d edges", len(edges), count)
@@ -366,8 +372,8 @@ func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Pa
 
 	var buf bytes.Buffer
 	if err := WriteDot(&buf, dot); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return buf.String(), nil
+	return buf.Bytes(), nil
 }

--- a/output.go
+++ b/output.go
@@ -5,15 +5,11 @@ import (
 	"fmt"
 	"go/build"
 	"go/types"
-	"io"
-	"os"
 	"strings"
 
 	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/ssa"
 )
-
-var output io.Writer = os.Stdout
 
 func isSynthetic(edge *callgraph.Edge) bool {
 	return edge.Caller.Func.Pkg == nil || edge.Callee.Func.Synthetic != ""
@@ -253,10 +249,12 @@ func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Pa
 						Attrs: dotAttrs{
 							"penwidth":  "0.8",
 							"fontsize":  "16",
-							"label":     label,
+							"label":     fmt.Sprintf("[%s]", label),
 							"style":     "filled",
 							"fillcolor": "lightyellow",
 							"URL":       fmt.Sprintf("/?f=%s", key),
+							"fontname":  "bold",
+							"tooltip":   fmt.Sprintf("package %s", label),
 						},
 					}
 					if pkg.Goroot {

--- a/output.go
+++ b/output.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"go/build"
 	"go/types"
@@ -23,7 +24,7 @@ func inStd(node *callgraph.Node) bool {
 	return pkg.Goroot
 }
 
-func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Package, limitPaths, ignorePaths []string, groupBy map[string]bool, nostd bool) error {
+func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Package, limitPaths, ignorePaths []string, groupBy map[string]bool, nostd bool) (string, error) {
 	groupType := groupBy["type"]
 	groupPkg := groupBy["pkg"]
 
@@ -304,7 +305,7 @@ func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Pa
 		return nil
 	})
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	logf("%d/%d edges", len(edges), count)
@@ -321,5 +322,10 @@ func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Pa
 		},
 	}
 
-	return WriteDot(output, dot)
+	var buf bytes.Buffer
+	if err := WriteDot(&buf, dot); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
 }

--- a/output.go
+++ b/output.go
@@ -214,6 +214,7 @@ func printOutput(mainPkg *types.Package, cg *callgraph.Graph, focusPkg *build.Pa
 							"label":     label,
 							"style":     "filled",
 							"fillcolor": "lightyellow",
+							"URL":       fmt.Sprintf("/?f=%s", key),
 						},
 					}
 					if pkg.Goroot {


### PR DESCRIPTION
This PR changes the normal behavior of go-callvis and now listens on port `:7979` and serves the output in SVG format with URL links set on packages so you can more interactively view the call graph.