### PR TITLE
Write as string instead of bytes when requesting dot format

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -104,7 +104,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	if r.Form.Get("format") == "dot" {
 		log.Println("writing dot output..")
-		fmt.Fprint(w, output)
+		fmt.Fprint(w, string(output))
 		return
 	}
 


### PR DESCRIPTION
This makes the output of `http://localhost:7878/?format=dot` a bit more readable ;)