### PR TITLE
Add options -format,-file for PNG/SVG file output

### DIFF
--- a/dot.go
+++ b/dot.go
@@ -31,10 +31,6 @@ func dotToImage(outfname string, format string, dot []byte) (string, error) {
 		dotExe = dot
 	}
 
-	if format != "svg" && format != "png" {
-		log.Fatalf("invalid output format %s\n", format)
-	}
-
 	var img string
 	if outfname == "" {
 		img = filepath.Join(os.TempDir(), fmt.Sprintf("go-callvis_export.%s", format))

--- a/dot.go
+++ b/dot.go
@@ -21,7 +21,8 @@ var (
 // it's usually at: /usr/bin/dot
 var dotExe string
 
-func dotToImage(dot []byte) (string, error) {
+// dotToImage generates a SVG using the 'dot' utility, returning the filepath
+func dotToImage(outfname string, format string, dot []byte) (string, error) {
 	if dotExe == "" {
 		dot, err := exec.LookPath("dot")
 		if err != nil {
@@ -30,8 +31,17 @@ func dotToImage(dot []byte) (string, error) {
 		dotExe = dot
 	}
 
-	img := filepath.Join(os.TempDir(), fmt.Sprintf("go-callvis_export.svg"))
-	cmd := exec.Command(dotExe, "-Tsvg", "-o", img)
+	if format != "svg" && format != "png" {
+		log.Fatalf("invalid output format %s\n", format)
+	}
+
+	var img string
+	if outfname == "" {
+		img = filepath.Join(os.TempDir(), fmt.Sprintf("go-callvis_export.%s", format))
+	} else {
+		img = fmt.Sprintf("%s.%s", outfname, format)
+	}
+	cmd := exec.Command(dotExe, fmt.Sprintf("-T%s", format), "-o", img)
 	cmd.Stdin = bytes.NewReader(dot)
 	if err := cmd.Run(); err != nil {
 		return "", err

--- a/dot.go
+++ b/dot.go
@@ -21,8 +21,7 @@ var (
 // it's usually at: /usr/bin/dot
 var dotExe string
 
-// dotToImage generates a SVG using the 'dot' utility, returning the filepath
-func dotToImage(outfname string, format string, dot []byte) (string, error) {
+func dotToImage(dot []byte) (string, error) {
 	if dotExe == "" {
 		dot, err := exec.LookPath("dot")
 		if err != nil {
@@ -30,18 +29,9 @@ func dotToImage(outfname string, format string, dot []byte) (string, error) {
 		}
 		dotExe = dot
 	}
-	
-	if format != "svg" && format != "png" {
-			log.Fatalf("invalid output format %s\n", format)
-	}
-	
-	var img string
-	if outfname == "" {
-			img = filepath.Join(os.TempDir(), fmt.Sprintf("go-callvis_export.%s", format))
-	} else {
-			img = fmt.Sprintf("%s.%s", outfname, format)
-	}
-	cmd := exec.Command(dotExe, fmt.Sprintf("-T%s", format), "-o", img)
+
+	img := filepath.Join(os.TempDir(), fmt.Sprintf("go-callvis_export.svg"))
+	cmd := exec.Command(dotExe, "-Tsvg", "-o", img)
 	cmd.Stdin = bytes.NewReader(dot)
 	if err := cmd.Run(); err != nil {
 		return "", err

--- a/dot.go
+++ b/dot.go
@@ -21,7 +21,8 @@ var (
 // it's usually at: /usr/bin/dot
 var dotExe string
 
-func dotToImage(dot []byte) (string, error) {
+// dotToImage generates a SVG using the 'dot' utility, returning the filepath
+func dotToImage(outfname string, format string, dot []byte) (string, error) {
 	if dotExe == "" {
 		dot, err := exec.LookPath("dot")
 		if err != nil {
@@ -29,9 +30,18 @@ func dotToImage(dot []byte) (string, error) {
 		}
 		dotExe = dot
 	}
-
-	img := filepath.Join(os.TempDir(), fmt.Sprintf("go-callvis_export.svg"))
-	cmd := exec.Command(dotExe, "-Tsvg", "-o", img)
+	
+	if format != "svg" && format != "png" {
+			log.Fatalf("invalid output format %s\n", format)
+	}
+	
+	var img string
+	if outfname == "" {
+			img = filepath.Join(os.TempDir(), fmt.Sprintf("go-callvis_export.%s", format))
+	} else {
+			img = fmt.Sprintf("%s.%s", outfname, format)
+	}
+	cmd := exec.Command(dotExe, fmt.Sprintf("-T%s", format), "-o", img)
 	cmd.Stdin = bytes.NewReader(dot)
 	if err := cmd.Run(); err != nil {
 		return "", err

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,9 +20,11 @@ cd $GOPATH/src/github.com/syncthing/syncthing
 ./build.sh
 ```
 
+# Generate graph and launch webserver
 ```sh
-go-callvis -focus upgrade -group pkg,type -limit github.com/syncthing/syncthing -ignore github.com/syncthing/syncthing/lib/logger github.com/syncthing/syncthing/cmd/syncthing | dot -Tpng -o syncthing.png
+go-callvis -focus upgrade -group pkg,type -limit github.com/syncthing/syncthing -ignore github.com/syncthing/syncthing/lib/logger github.com/syncthing/syncthing/cmd/syncthing
 ```
+
 ---
 
 ### Focusing package _upgrade_
@@ -30,7 +32,7 @@ go-callvis -focus upgrade -group pkg,type -limit github.com/syncthing/syncthing 
 [![syncthing example output](../images/syncthing_focus.png)](https://raw.githubusercontent.com/TrueFurby/go-callvis/master/images/syncthing_focus.png)
 
 ```sh
-go-callvis -focus upgrade -limit github.com/syncthing/syncthing github.com/syncthing/syncthing/cmd/syncthing | dot -Tpng -o syncthing_focus.png
+go-callvis -format=png -file=syncthing_focus -focus upgrade -limit github.com/syncthing/syncthing github.com/syncthing/syncthing/cmd/syncthing
 ```
 ---
 
@@ -38,8 +40,9 @@ go-callvis -focus upgrade -limit github.com/syncthing/syncthing github.com/synct
 
 [![syncthing example output pkg](../images/syncthing_group.png)](https://raw.githubusercontent.com/TrueFurby/go-callvis/master/images/syncthing_group.png)
 
+# Generate graph focused on module 'upgrade', output to PNG file
 ```sh
-go-callvis -focus upgrade -group pkg -limit github.com/syncthing/syncthing github.com/syncthing/syncthing/cmd/syncthing | dot -Tpng -o syncthing_group.png
+go-callvis -format=png -file=syncthing_group -focus upgrade -group pkg -limit github.com/syncthing/syncthing github.com/syncthing/syncthing/cmd/syncthing
 ```
 ---
 
@@ -47,8 +50,9 @@ go-callvis -focus upgrade -group pkg -limit github.com/syncthing/syncthing githu
 
 [![syncthing example output ignore](../images/syncthing_ignore.png)](https://raw.githubusercontent.com/TrueFurby/go-callvis/master/images/syncthing_ignore.png)
 
+# Generate graph focused on module 'upgrade' and ignoring 'logger', output to webserver
 ```sh
-go-callvis -focus upgrade -group pkg -ignore github.com/syncthing/syncthing/lib/logger -limit github.com/syncthing/syncthing github.com/syncthing/syncthing/cmd/syncthing | dot -Tpng -o syncthing_ignore.png
+go-callvis -focus upgrade -group pkg -ignore github.com/syncthing/syncthing/lib/logger -limit github.com/syncthing/syncthing github.com/syncthing/syncthing/cmd/syncthing
 ```
 ---
 
@@ -57,7 +61,7 @@ go-callvis -focus upgrade -group pkg -ignore github.com/syncthing/syncthing/lib/
 [![docker example](../images/docker.png)](https://raw.githubusercontent.com/TrueFurby/go-callvis/master/images/docker.png)
 
 ```sh
-go-callvis -limit github.com/docker/docker -ignore github.com/docker/docker/vendor github.com/docker/docker/cmd/docker | dot -Tpng -o docker.png
+go-callvis -format=png -file=docker -limit github.com/docker/docker -ignore github.com/docker/docker/vendor github.com/docker/docker/cmd/docker | dot -Tpng -o docker.png
 ```
 ---
 
@@ -66,5 +70,5 @@ go-callvis -limit github.com/docker/docker -ignore github.com/docker/docker/vend
 [![travis-example](../images/travis_thumb.jpg)](https://raw.githubusercontent.com/TrueFurby/go-callvis/master/images/travis.jpg)
 
 ```sh
-go-callvis -minlen 3 -nostd -group type,pkg -focus worker -limit github.com/travis-ci/worker -ignore github.com/travis-ci/worker/vendor github.com/travis-ci/worker/cmd/travis-worker > travis.dot && dot -Tsvg -o travis.svg travis.dot && exo-open travis.svg
+go-callvis -format=svg -file=travis -minlen 3 -nostd -group type,pkg -focus worker -limit github.com/travis-ci/worker -ignore github.com/travis-ci/worker/vendor github.com/travis-ci/worker/cmd/travis-worker && exo-open travis.svg
 ```

--- a/handler.go
+++ b/handler.go
@@ -122,8 +122,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Println("converting dot to svg..")
-	img, err := dotToImage("", "svg", output)
+	log.Printf("converting dot to %s..\n", *outputFormat)
+	img, err := dotToImage("", *outputFormat, output)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/handler.go
+++ b/handler.go
@@ -1,105 +1,11 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
 )
-
-func analysisSetup() (r renderOpts) {
-	r = renderOpts{
-		focus:   *focusFlag,
-		group:   []string{*groupFlag},
-		ignore:  []string{*ignoreFlag},
-		include: []string{*includeFlag},
-		limit:   []string{*limitFlag},
-		nointer: *nointerFlag,
-		nostd:   *nostdFlag}
-
-	return r
-}
-
-func processListArgs(r *renderOpts) (e error) {
-	var groupBy []string
-	for _, g := range strings.Split(r.group[0], ",") {
-		g := strings.TrimSpace(g)
-		if g == "" {
-			continue
-		}
-		if g != "pkg" && g != "type" {
-			e = errors.New("invalid group option")
-			return
-		}
-		groupBy = append(groupBy, g)
-	}
-	r.group = groupBy
-
-	var ignorePaths []string
-	for _, p := range strings.Split(r.ignore[0], ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			ignorePaths = append(ignorePaths, p)
-		}
-	}
-	r.ignore = ignorePaths
-
-	var includePaths []string
-	for _, p := range strings.Split(r.include[0], ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			includePaths = append(includePaths, p)
-		}
-	}
-	r.include = includePaths
-
-	var limitPaths []string
-	for _, p := range strings.Split(r.limit[0], ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			limitPaths = append(limitPaths, p)
-		}
-	}
-	r.limit = limitPaths
-
-	return
-}
-
-func outputDot(fname string, outputSvg, outputPng bool) {
-	// get cmdline default for analysis
-	opts := analysisSetup()
-	if e := processListArgs(&opts); e != nil {
-		log.Fatalf("%v\n", e)
-	}
-
-	output, err := Analysis.render(opts)
-	if err != nil {
-		log.Fatalf("%v\n", err)
-	}
-
-	log.Println("writing dot output..")
-	writeErr := ioutil.WriteFile(fmt.Sprintf("%s.gv", fname), output, 0755)
-	if writeErr != nil {
-		log.Fatalf("%v\n", writeErr)
-	}
-
-	if outputSvg {
-		log.Println("converting dot to svg..")
-		_, err := dotToImage(fmt.Sprintf("%s.gv", fname), "svg", output)
-		if err != nil {
-			log.Fatalf("%v\n", err)
-		}
-	}
-	if outputPng {
-		log.Println("converting dot to png..")
-		_, err := dotToImage(fmt.Sprintf("%s.gv", fname), "png", output)
-		if err != nil {
-			log.Fatalf("%v\n", err)
-		}
-	}
-}
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" && !strings.HasSuffix(r.URL.Path, ".svg") {
@@ -111,38 +17,83 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	logf(" => handling request:  %v", r.URL)
 	logf("----------------------")
 
-	// get cmdline default for analysis
-	opts := analysisSetup()
+	focus := *focusFlag
+	nostd := *nostdFlag
+	nointer := *nointerFlag
+	group := *groupFlag
+	limit := *limitFlag
+	ignore := *ignoreFlag
+	include := *includeFlag
 
-	// .. and allow overriding by HTTP params
 	if f := r.FormValue("f"); f == "all" {
-		opts.focus = ""
+		focus = ""
 	} else if f != "" {
-		opts.focus = f
+		focus = f
 	}
 	if std := r.FormValue("std"); std != "" {
-		opts.nostd = false
+		nostd = false
 	}
 	if inter := r.FormValue("nointer"); inter != "" {
-		opts.nointer = true
+		nointer = true
 	}
 	if g := r.FormValue("group"); g != "" {
-		opts.group[0] = g
+		group = g
 	}
 	if l := r.FormValue("limit"); l != "" {
-		opts.limit[0] = l
+		limit = l
 	}
 	if ign := r.FormValue("ignore"); ign != "" {
-		opts.ignore[0] = ign
+		ignore = ign
 	}
 	if inc := r.FormValue("include"); inc != "" {
-		opts.include[0] = inc
+		include = inc
 	}
 
-	// Convert list-style args to []string
-	if e := processListArgs(&opts); e != nil {
-		http.Error(w, "invalid group option", http.StatusInternalServerError)
-		return
+	var groupBy []string
+	for _, g := range strings.Split(group, ",") {
+		g := strings.TrimSpace(g)
+		if g == "" {
+			continue
+		}
+		if g != "pkg" && g != "type" {
+			http.Error(w, "invalid group option", http.StatusInternalServerError)
+			return
+		}
+		groupBy = append(groupBy, g)
+	}
+
+	var ignorePaths []string
+	for _, p := range strings.Split(ignore, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			ignorePaths = append(ignorePaths, p)
+		}
+	}
+
+	var includePaths []string
+	for _, p := range strings.Split(include, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			includePaths = append(includePaths, p)
+		}
+	}
+
+	var limitPaths []string
+	for _, p := range strings.Split(limit, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			limitPaths = append(limitPaths, p)
+		}
+	}
+
+	opts := renderOpts{
+		focus:   focus,
+		group:   groupBy,
+		ignore:  ignorePaths,
+		include: includePaths,
+		limit:   limitPaths,
+		nointer: nointer,
+		nostd:   nostd,
 	}
 
 	output, err := Analysis.render(opts)
@@ -158,7 +109,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Println("converting dot to svg..")
-	img, err := dotToImage("", "svg", output)
+	img, err := dotToImage(output)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -166,4 +117,5 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("serving file:", img)
 	http.ServeFile(w, r, img)
+
 }

--- a/handler.go
+++ b/handler.go
@@ -1,11 +1,105 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
 )
+
+func analysisSetup() (r renderOpts) {
+	r = renderOpts{
+		focus:   *focusFlag,
+		group:   []string{*groupFlag},
+		ignore:  []string{*ignoreFlag},
+		include: []string{*includeFlag},
+		limit:   []string{*limitFlag},
+		nointer: *nointerFlag,
+		nostd:   *nostdFlag}
+
+	return r
+}
+
+func processListArgs(r *renderOpts) (e error) {
+	var groupBy []string
+	for _, g := range strings.Split(r.group[0], ",") {
+		g := strings.TrimSpace(g)
+		if g == "" {
+			continue
+		}
+		if g != "pkg" && g != "type" {
+			e = errors.New("invalid group option")
+			return
+		}
+		groupBy = append(groupBy, g)
+	}
+	r.group = groupBy
+
+	var ignorePaths []string
+	for _, p := range strings.Split(r.ignore[0], ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			ignorePaths = append(ignorePaths, p)
+		}
+	}
+	r.ignore = ignorePaths
+
+	var includePaths []string
+	for _, p := range strings.Split(r.include[0], ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			includePaths = append(includePaths, p)
+		}
+	}
+	r.include = includePaths
+
+	var limitPaths []string
+	for _, p := range strings.Split(r.limit[0], ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			limitPaths = append(limitPaths, p)
+		}
+	}
+	r.limit = limitPaths
+
+	return
+}
+
+func outputDot(fname string, outputSvg, outputPng bool) {
+	// get cmdline default for analysis
+	opts := analysisSetup()
+	if e := processListArgs(&opts); e != nil {
+		log.Fatalf("%v\n", e)
+	}
+
+	output, err := Analysis.render(opts)
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
+
+	log.Println("writing dot output..")
+	writeErr := ioutil.WriteFile(fmt.Sprintf("%s.gv", fname), output, 0755)
+	if writeErr != nil {
+		log.Fatalf("%v\n", writeErr)
+	}
+
+	if outputSvg {
+		log.Println("converting dot to svg..")
+		_, err := dotToImage(fmt.Sprintf("%s.gv", fname), "svg", output)
+		if err != nil {
+			log.Fatalf("%v\n", err)
+		}
+	}
+	if outputPng {
+		log.Println("converting dot to png..")
+		_, err := dotToImage(fmt.Sprintf("%s.gv", fname), "png", output)
+		if err != nil {
+			log.Fatalf("%v\n", err)
+		}
+	}
+}
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" && !strings.HasSuffix(r.URL.Path, ".svg") {
@@ -17,83 +111,38 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	logf(" => handling request:  %v", r.URL)
 	logf("----------------------")
 
-	focus := *focusFlag
-	nostd := *nostdFlag
-	nointer := *nointerFlag
-	group := *groupFlag
-	limit := *limitFlag
-	ignore := *ignoreFlag
-	include := *includeFlag
+	// get cmdline default for analysis
+	opts := analysisSetup()
 
+	// .. and allow overriding by HTTP params
 	if f := r.FormValue("f"); f == "all" {
-		focus = ""
+		opts.focus = ""
 	} else if f != "" {
-		focus = f
+		opts.focus = f
 	}
 	if std := r.FormValue("std"); std != "" {
-		nostd = false
+		opts.nostd = false
 	}
 	if inter := r.FormValue("nointer"); inter != "" {
-		nointer = true
+		opts.nointer = true
 	}
 	if g := r.FormValue("group"); g != "" {
-		group = g
+		opts.group[0] = g
 	}
 	if l := r.FormValue("limit"); l != "" {
-		limit = l
+		opts.limit[0] = l
 	}
 	if ign := r.FormValue("ignore"); ign != "" {
-		ignore = ign
+		opts.ignore[0] = ign
 	}
 	if inc := r.FormValue("include"); inc != "" {
-		include = inc
+		opts.include[0] = inc
 	}
 
-	var groupBy []string
-	for _, g := range strings.Split(group, ",") {
-		g := strings.TrimSpace(g)
-		if g == "" {
-			continue
-		}
-		if g != "pkg" && g != "type" {
-			http.Error(w, "invalid group option", http.StatusInternalServerError)
-			return
-		}
-		groupBy = append(groupBy, g)
-	}
-
-	var ignorePaths []string
-	for _, p := range strings.Split(ignore, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			ignorePaths = append(ignorePaths, p)
-		}
-	}
-
-	var includePaths []string
-	for _, p := range strings.Split(include, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			includePaths = append(includePaths, p)
-		}
-	}
-
-	var limitPaths []string
-	for _, p := range strings.Split(limit, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			limitPaths = append(limitPaths, p)
-		}
-	}
-
-	opts := renderOpts{
-		focus:   focus,
-		group:   groupBy,
-		ignore:  ignorePaths,
-		include: includePaths,
-		limit:   limitPaths,
-		nointer: nointer,
-		nostd:   nostd,
+	// Convert list-style args to []string
+	if e := processListArgs(&opts); e != nil {
+		http.Error(w, "invalid group option", http.StatusInternalServerError)
+		return
 	}
 
 	output, err := Analysis.render(opts)
@@ -109,7 +158,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Println("converting dot to svg..")
-	img, err := dotToImage(output)
+	img, err := dotToImage("", "svg", output)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -117,5 +166,4 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("serving file:", img)
 	http.ServeFile(w, r, img)
-
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,9 @@ var (
 	versionFlag = flag.Bool("version", false, "Show version and exit.")
 	httpFlag    = flag.String("http", ":7878", "HTTP service address.")
 	skipBrowser = flag.Bool("skipbrowser", false, "Skip opening browser.")
+	outputFile  = flag.String("output", "", "output file - just output .gv (dot) file, no http service")
+	svgFlag     = flag.Bool("svg", false, "use with -output, also output .svg file")
+	pngFlag     = flag.Bool("png", false, "use with -output, also output .png file")
 )
 
 func init() {
@@ -81,14 +84,18 @@ func main() {
 
 	http.HandleFunc("/", handler)
 
-	log.Printf("http serving at %s", urlAddr)
+	if *outputFile != "" {
+		outputDot(*outputFile, *svgFlag, *pngFlag)
+	} else {
+		if !*skipBrowser {
+			go openBrowser(urlAddr)
+		}
 
-	if !*skipBrowser {
-		go openBrowser(urlAddr)
-	}
+		log.Printf("http serving at %s", urlAddr)
 
-	if err := http.ListenAndServe(httpAddr, nil); err != nil {
-		log.Fatal(err)
+		if err := http.ListenAndServe(httpAddr, nil); err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -34,9 +34,6 @@ var (
 	versionFlag = flag.Bool("version", false, "Show version and exit.")
 	httpFlag    = flag.String("http", ":7878", "HTTP service address.")
 	skipBrowser = flag.Bool("skipbrowser", false, "Skip opening browser.")
-	outputFile  = flag.String("output", "", "output file - just output .gv (dot) file, no http service")
-	svgFlag     = flag.Bool("svg", false, "use with -output, also output .svg file")
-	pngFlag     = flag.Bool("png", false, "use with -output, also output .png file")
 )
 
 func init() {
@@ -84,18 +81,14 @@ func main() {
 
 	http.HandleFunc("/", handler)
 
-	if *outputFile != "" {
-		outputDot(*outputFile, *svgFlag, *pngFlag)
-	} else {
-		if !*skipBrowser {
-			go openBrowser(urlAddr)
-		}
+	log.Printf("http serving at %s", urlAddr)
 
-		log.Printf("http serving at %s", urlAddr)
+	if !*skipBrowser {
+		go openBrowser(urlAddr)
+	}
 
-		if err := http.ListenAndServe(httpAddr, nil); err != nil {
-			log.Fatal(err)
-		}
+	if err := http.ListenAndServe(httpAddr, nil); err != nil {
+		log.Fatal(err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -118,15 +118,7 @@ func main() {
 			log.Fatal(err)
 		}
 	} else {
-
-		switch *outputFormat {
-		case "svg":
-			outputDot(*outputFile, *outputFormat)
-		case "png":
-			outputDot(*outputFile, *outputFormat)
-		default:
-			outputDot(*outputFile, *outputFormat)
-		}
+		outputDot(*outputFile, *outputFormat)
 	}
 }
 


### PR DESCRIPTION
Addition of -output, -svg, -png options to run go-callvis in a non-server mode to just output image files.
Useful for scripting eg., makefile targets to generate graphvis for modules non-interactively.
