### PR TITLE
Ignore flag handles type

### DIFF
--- a/output.go
+++ b/output.go
@@ -142,6 +142,20 @@ func printOutput(
 		return false
 	}
 
+	var inIgnoreTypes = func(node *callgraph.Node) bool {
+		params := node.Func.Params
+		if len(params) == 0 || params[0] == nil {
+			return false
+		}
+
+		for _, ignored := range ignorePaths {
+			if params[0].Type().String() == ignored {
+				return true
+			}
+		}
+		return false
+	}
+
 	var isInter = func(edge *callgraph.Edge) bool {
 		//caller := edge.Caller
 		callee := edge.Callee
@@ -208,7 +222,8 @@ func printOutput(
 
 			// ignore path prefixes
 			if len(ignorePaths) > 0 &&
-				(inIgnores(caller) || inIgnores(callee)) {
+				(inIgnores(caller) || inIgnores(callee)) ||
+				inIgnoreTypes(caller) || inIgnoreTypes(callee) {
 				logf("IS ignored: %s -> %s", caller, callee)
 				return nil
 			}


### PR DESCRIPTION
Add ability to ignore types. Similar to ignoring packages.
It is useful when we have code like below and a lot of code calls `status.String()`, so it has a lot of input arrows on graph
```go
type Status string

func (s Status) String() string {
  return s
}
```

Before:

Output for 
```bash
go-callvis -algo rta -group type,pkg -focus github.com/syncthing/syncthing/lib/upgrade -limit github.com/syncthing/syncthing -ignore github.com/syncthing/syncthing/lib/logger,github.com/syncthing/syncthing/internal/db/sqlite,github.com/syncthing/syncthing/lib/connections,github.com/syncthing/syncthing/internal/db/olddb/backend,github.com/syncthing/syncthing/lib/fs,github.com/syncthing/syncthing/lib/osutil,github.com/syncthing/syncthing/internal/db github.com/syncthing/cmd/syncthing/
```

<img width="1659" height="852" alt="Снимок экрана 2025-07-20 в 21 18 42" src="https://github.com/user-attachments/assets/de8bfb11-fe4c-4982-948b-9c6acc632a03" />

---
After: 

Output for 
```bash
go-callvis -algo rta -group type,pkg -focus github.com/syncthing/syncthing/lib/upgrade -limit github.com/syncthing/syncthing -ignore github.com/syncthing/syncthing/lib/logger,github.com/syncthing/syncthing/internal/db/sqlite,github.com/syncthing/syncthing/lib/connections,github.com/syncthing/syncthing/internal/db/olddb/backend,github.com/syncthing/syncthing/lib/fs,github.com/syncthing/syncthing/lib/osutil,github.com/syncthing/syncthing/internal/db,'*github.com/syncthing/syncthing/cmd/syncthing.autoclosedFile' github.com/syncthing/cmd/syncthing/
```
Added flag `-ignore '*github.com/syncthing/syncthing/cmd/syncthing.autoclosedFile'`

<img width="1382" height="636" alt="Снимок экрана 2025-07-20 в 21 17 03" src="https://github.com/user-attachments/assets/6f18e93e-14dd-45da-b661-ecc9311021a1" />

